### PR TITLE
Fix import error in installations without pytroll extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Downsat offers a simplified approach to downloading and managing meteorological 
 
 ### [Satpy](#satpy-1)
 
-- Satpy scene: `from downsat import SatpyScene`
-- Satpy composite image: `from downsat import SatpyProduct`
+- Satpy scene: `from downsat.satpy import SatpyScene`
+- Satpy composite image: `from downsat.satpy import SatpyProduct`
 
 ### [Historical TLE - spacetrack](#tle)
 
@@ -170,7 +170,7 @@ The downsat data sources are well-suited for integration with satpy
 #### Creating satpy product
 
 ```python
-from downsat import SatpyProduct
+from downsat.satpy import SatpyProduct
 
 msg = MSG.from_env(data_path=data_path)
 natural_color = SatpyProduct(msg, "natural_color", area="eurol")

--- a/downsat/__init__.py
+++ b/downsat/__init__.py
@@ -11,7 +11,17 @@ from downsat.data_sources.satellite_info import (
     satellite_info_geo,
     satellite_info_leo,
 )
-from downsat.data_sources.satpy import SatpyProduct, SatpyScene
+
+
+try:
+    from downsat.data_sources.satpy import (  # TODO: this is deprecated -> remove; users should import this from downsat.satpy
+        SatpyProduct,
+        SatpyScene,
+    )
+except ImportError:
+    _satpy_available = False
+else:
+    _satpy_available = True
 from downsat.data_sources.tle import DailyTLE
 
 
@@ -30,6 +40,7 @@ __all__ = [
     "satellite_info_geo",
     "satellite_info_leo",
     "satellite_info",
-    "SatpyProduct",
-    "SatpyScene",
 ]
+
+if _satpy_available:
+    __all__ += ["SatpyProduct", "SatpyScene"]

--- a/downsat/satpy/__init__.py
+++ b/downsat/satpy/__init__.py
@@ -1,0 +1,7 @@
+from downsat.data_sources.satpy import SatpyProduct, SatpyScene
+
+
+__all__ = [
+    "SatpyProduct",
+    "SatpyScene",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,3 +200,16 @@ def random_xrimage() -> "XRImage":
 
     # Convert the DataArray to an RGB XRImage
     return XRImage(da)
+
+
+# extras
+
+
+@pytest.fixture
+def is_satpy_available() -> bool:
+    try:
+        pass
+    except ImportError:
+        pytest.skip("Satpy is not available.")
+
+    return True

--- a/tests/data_sources/test_satpy.py
+++ b/tests/data_sources/test_satpy.py
@@ -15,7 +15,10 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize("channels", [["IR_108"], "IR_108"], ids=["channels_list", "channels_str"])
 @pytest.mark.parametrize("area", [None, "germ"], ids=["no_area", "germ"])
 def test_to_satpy_scene(
-    msg_archive: "protocols.MultiKeyDataSource", area: str | None, channels: list[str] | str
+    msg_archive: "protocols.MultiKeyDataSource",
+    area: str | None,
+    channels: list[str] | str,
+    is_satpy_available: bool,  # noqa: U100
 ) -> None:
     from satpy import Scene
 
@@ -32,7 +35,7 @@ def test_to_satpy_scene(
     # TODO: test that the scene was resampled
 
 
-def test_to_satpy_scene_no_channels_to_resample() -> None:
+def test_to_satpy_scene_no_channels_to_resample(is_satpy_available: bool) -> None:  # noqa: U100
     from downsat.data_sources.satpy import ToSatpyScene
 
     with pytest.raises(ValueError):
@@ -40,7 +43,9 @@ def test_to_satpy_scene_no_channels_to_resample() -> None:
 
 
 @pytest.mark.parametrize("area", [None, "germ"], ids=["no_area", "germ"])
-def test_satpy_scene(msg_archive_path: Path, eumdac_key: "EumdacKey", area: str | None) -> None:
+def test_satpy_scene(
+    msg_archive_path: Path, eumdac_key: "EumdacKey", area: str | None, is_satpy_available: bool  # noqa: U100
+) -> None:
     from satpy import Scene
 
     from downsat import MSG
@@ -72,7 +77,7 @@ def test_satpy_scene(msg_archive_path: Path, eumdac_key: "EumdacKey", area: str 
 @pytest.mark.parametrize("composite", ["IR_108", "natural_color"], ids=["IR_108", "natural_color"])
 @pytest.mark.parametrize("area", [None, "germ"], ids=["no_area", "germ"])
 def test_to_satpy_product(
-    msg_archive: "protocols.MultiKeyDataSource", area: str | None, composite: str
+    msg_archive: "protocols.MultiKeyDataSource", area: str | None, composite: str, is_satpy_available: bool  # noqa: U100
 ) -> None:
     from trollimage.xrimage import XRImage
 
@@ -97,7 +102,9 @@ def test_to_satpy_product(
 
 
 @pytest.mark.parametrize("area", [None, "germ"], ids=["no_area", "germ"])
-def test_satpy_product(msg_archive_path: Path, eumdac_key: "EumdacKey", area: str | None) -> None:
+def test_satpy_product(
+    msg_archive_path: Path, eumdac_key: "EumdacKey", area: str | None, is_satpy_available: bool  # noqa: U100
+) -> None:
     from trollimage.xrimage import XRImage
 
     from downsat import MSG
@@ -131,7 +138,9 @@ def test_satpy_product(msg_archive_path: Path, eumdac_key: "EumdacKey", area: st
     assert all(isinstance(s, XRImage) for s in prod)
 
 
-def test_cached_satpy_product(msg_archive: "protocols.MultiKeyDataSource", tmp_path: Path) -> None:
+def test_cached_satpy_product(
+    msg_archive: "protocols.MultiKeyDataSource", tmp_path: Path, is_satpy_available: bool  # noqa: U100
+) -> None:
     from downsat.etl.metadata import getmeta
     from downsat.satpy import SatpyProduct
 

--- a/tests/data_sources/test_satpy.py
+++ b/tests/data_sources/test_satpy.py
@@ -43,7 +43,8 @@ def test_to_satpy_scene_no_channels_to_resample() -> None:
 def test_satpy_scene(msg_archive_path: Path, eumdac_key: "EumdacKey", area: str | None) -> None:
     from satpy import Scene
 
-    from downsat import MSG, SatpyScene
+    from downsat import MSG
+    from downsat.satpy import SatpyScene
 
     msg = MSG(eumdac_key, msg_archive_path)
     scene_archive = SatpyScene(msg, reader="seviri_l1b_native", area=area, channels=["IR_108"])
@@ -75,10 +76,10 @@ def test_to_satpy_product(
 ) -> None:
     from trollimage.xrimage import XRImage
 
-    from downsat import SatpyScene
     from downsat.data_sources.satpy import ToSatpyProduct, ToSatpyScene
     from downsat.etl.class_transforms import reduce
     from downsat.etl.metadata import getmeta
+    from downsat.satpy import SatpyScene
 
     scene_archive = reduce(msg_archive, ToSatpyScene)(reader="seviri_l1b_native", area=area, channels=composite)  # type: ignore  # TODO: fix by mypy plugin
     product_archive = (scene_archive >> ToSatpyProduct)(composite=composite)  # type: ignore  # TODO: fix by mypy plugin
@@ -99,7 +100,8 @@ def test_to_satpy_product(
 def test_satpy_product(msg_archive_path: Path, eumdac_key: "EumdacKey", area: str | None) -> None:
     from trollimage.xrimage import XRImage
 
-    from downsat import MSG, SatpyProduct
+    from downsat import MSG
+    from downsat.satpy import SatpyProduct
 
     msg = MSG(eumdac_key, msg_archive_path)
     product_archive = SatpyProduct(msg, "natural_color", reader="seviri_l1b_native", area=area)
@@ -130,8 +132,8 @@ def test_satpy_product(msg_archive_path: Path, eumdac_key: "EumdacKey", area: st
 
 
 def test_cached_satpy_product(msg_archive: "protocols.MultiKeyDataSource", tmp_path: Path) -> None:
-    from downsat import SatpyProduct
     from downsat.etl.metadata import getmeta
+    from downsat.satpy import SatpyProduct
 
     product_archive_with_cache = SatpyProduct(
         msg_archive, reader="seviri_l1b_native", area="germ", composite="IR_108", cache_path=tmp_path

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from downsat.clients.spacetrack import SpaceTrackKey
 
 
-def test_downloading_data(msg_archive_path: Path, eumdac_key: "EumdacKey") -> None:
+def test_downloading_data_msg(msg_archive_path: Path, eumdac_key: "EumdacKey") -> None:
     from downsat import MSG
 
     # --- downloading data
@@ -31,16 +31,24 @@ def test_downloading_data(msg_archive_path: Path, eumdac_key: "EumdacKey") -> No
 
     EumdacCollection(name="MSG", credentials=key).collection.search_options
 
+
+def test_downloading_data_metop(metop_archive_path: Path) -> None:
     # --- Downloading data to cover certain point of region of interest
     from downsat import Metop
 
-    metop = Metop.from_env(data_path=msg_archive_path, area="eurol")
+    metop = Metop.from_env(data_path=metop_archive_path, area="eurol")
     metop["2022110411"]
 
     from downsat import LonLat
 
-    metop = Metop.from_env(data_path=msg_archive_path, point=LonLat(lon=14.46, lat=50.0))
+    metop = Metop.from_env(data_path=metop_archive_path, point=LonLat(lon=14.46, lat=50.0))
     metop["2022110411"]
+
+
+def test_downloading_data_satpy(msg_archive_path: Path, is_satpy_available: bool) -> None:  # noqa: U100
+    from downsat import MSG
+
+    msg = MSG.from_env(data_path=msg_archive_path, sat="MSG4")
 
     # --- Satpy
     from satpy import Scene

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -51,7 +51,7 @@ def test_downloading_data(msg_archive_path: Path, eumdac_key: "EumdacKey") -> No
     # --- SatpyProduct
     from trollimage.xrimage import XRImage
 
-    from downsat import SatpyProduct
+    from downsat.satpy import SatpyProduct
 
     msg = MSG.from_env(data_path=msg_archive_path, num_workers=3)
     natural_color = SatpyProduct(msg, "natural_color", area="eurol")
@@ -66,7 +66,7 @@ def test_downloading_data(msg_archive_path: Path, eumdac_key: "EumdacKey") -> No
     assert isinstance(image2, XRImage)
 
     # --- SatpyScene
-    from downsat import SatpyScene
+    from downsat.satpy import SatpyScene
 
     msg = MSG.from_env(data_path=msg_archive_path, num_workers=3, flatten=True)
     scn = SatpyScene(msg, reader="seviri_l1b_native", channels="IR_108", area="eurol")


### PR DESCRIPTION
Issue: it was not possible to `import downsat` at all when `downsat` was installed without `pytroll` extras due to import of `SatpyScene` and `SatpyProduct` in the main `__init__.py`.

Solution: 

- move `SatpyProduct` and `SatpyScene` from `downsat` to `downsat.satpy` and ammend documentation.
- `import downsat.SatpyProduct` and `import downsat.SatpyScene` still work when satpy is installed and raise `ImportError` when not, but their use is deprecated and will be removed in the future.
- tests using satpy are skipped when satpy is not available